### PR TITLE
improve font-locking for defun-tco

### DIFF
--- a/tco.el
+++ b/tco.el
@@ -82,6 +82,13 @@ BODY must contain calls to FUNCTION-NAME in the tail position."
              (setq ,result (funcall ,result)))
            ,result)))))
 
+;; style defun-tco like defun
+(font-lock-add-keywords
+ 'emacs-lisp-mode
+ '(("(\\(defun-tco\\)\\_>\\s *\\(\\(?:\\sw\\|\\s_\\)+\\)?"
+    (1 font-lock-keyword-face nil t)
+    (2 font-lock-function-name-face nil t))))
+
 (provide 'tco)
 ;;; tco.el ends here
 


### PR DESCRIPTION
Cf. https://emacs.stackexchange.com/questions/47053/use-defun-font-locking-for-other-keywords/47059?noredirect=1#comment72451_47059

(It would be nice also if the docstring could be styled to look like a `defun` docstring.)