### PR TITLE
Fix issues reported by package-lint-current-buffer

### DIFF
--- a/tco.el
+++ b/tco.el
@@ -1,10 +1,11 @@
-;;; tco.el --- tail-call optimisation for Emacs lisp -*- lexical-binding: t -*-
+;;; tco.el --- Tail-call optimisation for Emacs lisp -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013, 2016, 2017, 2019 Wilfred Hughes
 
 ;; Author: Wilfred Hughes <me@wilfred.me.uk>
 ;; Version: 0.3
-;; Package-Requires: ((dash "1.2.0") (emacs "24"))
+;; URL: https://github.com/Wilfred/tco.el
+;; Package-Requires: ((dash "1.2.0") (emacs "24.3"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This fixes the following 4 issues reported by package-lint

```
4 issues found:

1:0: error: Package should have a Homepage or URL header.
1:0: warning: The package summary should start with an uppercase letter or a digit.
49:29: error: You should depend on (emacs "24.3") or the cl-lib package if you need `cl-lib'.
81:8: error: You should depend on (emacs "24.3") or the cl-lib package if you need `cl-letf'.
```